### PR TITLE
chore: update base image to latest version known to work with mw 1.39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wikibase/wdqs:0.3.6
+FROM wikibase/wdqs:0.3.135-wmde.13
 
 LABEL org.opencontainers.image.source="https://github.com/wbstack/queryservice"
 


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T361551