### PR TITLE
gh-actions: move to docker/metadata-action

### DIFF
--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -18,7 +18,7 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v5.5.1
+        uses: docker/metadata-action@v5.5.1
         with:
           images: ghcr.io/${{ github.repository }}
       -


### PR DESCRIPTION
Moved as per: https://github.com/docker/metadata-action/blob/master/UPGRADE.md