### PR TITLE
add User-Agent env var

### DIFF
--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.3.0
       -
         name: Cache Docker layers
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM wikibase/wdqs:0.3.135-wmde.13
+ARG VERSION=0.3.135-wmde.13
+FROM wikibase/wdqs:$VERSION
+ARG VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/wbstack/queryservice"
 
-ENV USER_AGENT="Wikibase.Cloud Query Service; https://wikibase.cloud/"}
+ENV USER_AGENT="Wikibase.Cloud Query Service ($VERSION); https://wikibase.cloud/"}
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/wbstack/queryservice"
 
-ENV USER_AGENT="Wikibase.Cloud Query Service ($VERSION); https://wikibase.cloud/"}
+ENV USER_AGENT="Wikibase.Cloud Query Service ($VERSION); https://wikibase.cloud/"
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/wbstack/queryservice"
 
-ENV USER_AGENT="Wikibase.Cloud Query Service ($VERSION); https://wikibase.cloud/"
+ENV USER_AGENT="Wikibase.Cloud Query Service ($VERSION); https://github.com/wbstack/queryservice"
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM wikibase/wdqs:0.3.135-wmde.13
 
 LABEL org.opencontainers.image.source="https://github.com/wbstack/queryservice"
 
+ENV USER_AGENT="Wikibase.Cloud Query Service; https://wikibase.cloud/"}
+
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T397052

- Adds a custom User-Agent string to Blazegraph requests when running federated queries
- Includes the wdqs image version it depends on, see https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact
- fixes outdated github cache action version number

```
bash-4.4# env | grep USER
USER_AGENT=Wikibase.Cloud Query Service (0.3.135-wmde.13); https://github.com/wbstack/queryservice
```

- for verification, skaffold this image and try inspecting platform-nginx logs while using the Query Service
  - `kubectl logs -f deployments/platform-nginx` 